### PR TITLE
Fuzzing Vulnerability Fixes

### DIFF
--- a/can-auth/leia.c
+++ b/can-auth/leia.c
@@ -322,7 +322,7 @@ int VULCAN_FUNC vulcan_recv(ican_t *ican, uint16_t *id, uint8_t *buf, int block)
         return -EINVAL;
 
     /* 2. authenticated connection ? process AUTH_FAIL response, if any */
-    if (!leia_find_connection(*id)) return rv;
+    if (!leia_find_connection(*id)) return -EINVAL;
     if ((auth_fail_resp = ((cmd == LEIA_CMD_AEC_EPOCH) && !leia_cur->c)))
     {
         ASSERT(rv == CAN_PAYLOAD_SIZE);

--- a/can-auth/vatican.c
+++ b/can-auth/vatican.c
@@ -227,7 +227,7 @@ int VULCAN_FUNC vulcan_recv(ican_t *ican, uint16_t *id, uint8_t *buf, int block)
     ican_buf_t mac_me;
     ican_buf_t mac_recv;
     uint16_t id_recv;
-    int rv, recv_len, i, fail = 0;
+    int rv, recv_len, i, fail = 1;
 
     /* 1. receive any CAN message (ID | payload) */
     if ((rv = vatican_receive(ican, id, buf, block)) < 0)


### PR DESCRIPTION
During Fuzz testing of VulCAN, it was discovered that both VatiCAN and LeiA exhibited bugs that allowed an unauthenticated user to adjust the RPM LEDs at will on the demo bench.
The LEDs would respond with "GOOD" and an RPM value calculated from the unauthenticated message.

The bugs occurred when performing moderate flooding with extended CAN ID packets.
Extended CAN ID packets were/are broadcast on ID 0x0, which meant that they caused garbled authenticated packets but also arrived on the right component due to being broadcast.

The following fixes patch some of that behavior.
They cause these garbled packets to be outright rejected instead of being accepted and causing an LED adjustment.